### PR TITLE
Task: Remove gradle wrapper validation - Starting with v4 the setup-gradle action will automatically perform wrapper validation on each execution.

### DIFF
--- a/.github/workflows/check_and_deploy.yml
+++ b/.github/workflows/check_and_deploy.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
@@ -96,9 +93,6 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-
-      - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
 
       - name: Accept Android licenses
         run: yes | "$ANDROID_HOME"/cmdline-tools/latest/bin/sdkmanager --licenses || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
       ## Actual task
       - name: Build
         uses: gradle/gradle-build-action@v2
@@ -62,9 +59,6 @@ jobs:
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-
-      - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
 
       - name: Build
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
https://github.com/gradle/actions/blob/aa23778d2dc6f6556fcc7164e99babbd8c3134e4/docs/wrapper-validation.md